### PR TITLE
ADX-782 Allow restoring the same release multiple times

### DIFF
--- a/ckanext/versions/logic/dataset_version_action.py
+++ b/ckanext/versions/logic/dataset_version_action.py
@@ -123,7 +123,7 @@ def dataset_version_restore(context, data_dict):
     v_notes = _("Restored from version: {}").format(version['name'])
 
     releases = dataset_version_list(context, {'dataset_id': dataset_name_or_id})
-    release_names = [v['name'] for v in releases]
+    release_names = {v['name'] for v in releases}
     counter = 1
     while v_name in release_names:
         v_name = "{}_{}_{}".format(v_name_prefix, counter, version['name'])

--- a/ckanext/versions/logic/dataset_version_action.py
+++ b/ckanext/versions/logic/dataset_version_action.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from sqlalchemy.exc import IntegrityError
 
 from ckan import model as core_model
+from ckan.common import _
 from ckan.plugins import toolkit
 from ckanext.versions.logic.action import version_show
 from ckanext.versions.model import Version
@@ -116,8 +117,18 @@ def dataset_version_restore(context, data_dict):
     version = version_show(context, data_dict)
     if not version:
         raise toolkit.ObjectNotFound("Version not found")
-    v_name = "restored_{}".format(version['name'])
-    v_notes = "Restored from version: {}".format(version['name'])
+
+    v_name_prefix = _("restored")
+    v_name = "{}_{}".format(v_name_prefix, version['name'])
+    v_notes = _("Restored from version: {}").format(version['name'])
+
+    releases = dataset_version_list(context, {'dataset_id': dataset_name_or_id})
+    release_names = [v['name'] for v in releases]
+    counter = 1
+    while v_name in release_names:
+        v_name = "{}_{}_{}".format(v_name_prefix, counter, version['name'])
+        counter += 1
+
     old_dataset = activity_dataset_show(
         context,
         {

--- a/ckanext/versions/tests/test_dataset_version_action.py
+++ b/ckanext/versions/tests/test_dataset_version_action.py
@@ -186,10 +186,10 @@ class TestDatasetVersion(object):
                 order_by(Version.created.desc()).first().name
             if counter:
                 assert new_name == "{}_{}_{}".format(prefix, counter, test_version['name']), \
-                    "restored version did not have the exected name"
+                    "restored version did not have the expected name"
             else:
                 assert new_name == "{}_{}".format(prefix, test_version['name']), \
-                    "restored version did not have the exected name"
+                    "restored version did not have the expected name"
 
     def test_dataset_version_restore_fails_if_dataset_not_found(self, test_version, test_dataset, org_editor):
         with pytest.raises(toolkit.ObjectNotFound, match="Dataset not found"):

--- a/ckanext/versions/tests/test_dataset_version_action.py
+++ b/ckanext/versions/tests/test_dataset_version_action.py
@@ -176,6 +176,21 @@ class TestDatasetVersion(object):
 
         assert latest_version.id != test_version['id'], "restore action should create a new version"
 
+    def test_dataset_version_restore_naming_for_multiple_restores(self, test_version, test_dataset, org_editor):
+        number_of_restores = 5
+        prefix = "restored"
+        for counter in range(number_of_restores):
+            restore_version(test_dataset['id'], test_version['id'], org_editor)
+            new_name = model.Session.query(Version). \
+                filter(Version.package_id == test_dataset['id']). \
+                order_by(Version.created.desc()).first().name
+            if counter:
+                assert new_name == "{}_{}_{}".format(prefix, counter, test_version['name']), \
+                    "restored version did not have the exected name"
+            else:
+                assert new_name == "{}_{}".format(prefix, test_version['name']), \
+                    "restored version did not have the exected name"
+
     def test_dataset_version_restore_fails_if_dataset_not_found(self, test_version, test_dataset, org_editor):
         with pytest.raises(toolkit.ObjectNotFound, match="Dataset not found"):
             restore_version('fake-dataset-id', test_version['id'], org_editor)


### PR DESCRIPTION
The name of the release must be unique.  The restored releases were being given names such that you couldn't restore the same release twice since the second restore of the release had the same name as the first restore of the release.

This PR addresses the issue and adds a regression test. 

New restored releases have names:

- "restored_original name"
- "restored_1_original_name"
- "restored_2_original_name"
- "restored_3_original_name"
- ...and so on
